### PR TITLE
Implemented hooks and callbacks in ExtensibleSaveFormat for CharaStudio scenes (load/import/save)

### DIFF
--- a/ExtensibleSaveFormat/ExtendedSave.cs
+++ b/ExtensibleSaveFormat/ExtendedSave.cs
@@ -4,10 +4,11 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Studio;
 
 namespace ExtensibleSaveFormat
 {
-    [BepInPlugin(GUID: "com.bepis.bepinex.extendedsave", Name: "Extended Save", Version: "1.3")]
+    [BepInPlugin(GUID: "com.bepis.bepinex.extendedsave", Name: "Extended Save", Version: "1.4")]
     public class ExtendedSave : BaseUnityPlugin
     {
         void Awake()
@@ -15,7 +16,9 @@ namespace ExtensibleSaveFormat
             Hooks.InstallHooks();
         }
 
-        internal static WeakKeyDictionary<ChaFile, Dictionary<string, PluginData>> internalDictionary = new WeakKeyDictionary<ChaFile, Dictionary<string, PluginData>>();
+        internal static WeakKeyDictionary<ChaFile, Dictionary<string, PluginData>> internalCharaDictionary = new WeakKeyDictionary<ChaFile, Dictionary<string, PluginData>>();
+
+        internal static Dictionary<string, PluginData> internalSceneDictionary = new Dictionary<string, PluginData>();
 
         #region Events
 
@@ -25,21 +28,44 @@ namespace ExtensibleSaveFormat
 
         public static event CardEventHandler CardBeingLoaded;
 
-        internal static void writeEvent(ChaFile file)
+        public delegate void SceneEventHandler(string path);
+
+        public static event SceneEventHandler SceneBeingSaved;
+
+        public static event SceneEventHandler SceneBeingLoaded;
+
+        public static event SceneEventHandler SceneBeingImported;
+
+        internal static void cardWriteEvent(ChaFile file)
         {
             CardBeingSaved?.Invoke(file);
         }
 
-        internal static void readEvent(ChaFile file)
+        internal static void cardReadEvent(ChaFile file)
         {
             CardBeingLoaded?.Invoke(file);
+        }
+
+        internal static void sceneWriteEvent(string path)
+        {
+            SceneBeingSaved?.Invoke(path);
+        }
+
+        internal static void sceneReadEvent(string path)
+        {
+            SceneBeingLoaded?.Invoke(path);
+        }
+
+        internal static void sceneImportEvent(string path)
+        {
+            SceneBeingImported?.Invoke(path);
         }
 
         #endregion
 
         public static Dictionary<string, PluginData> GetAllExtendedData(ChaFile file)
         {
-            return internalDictionary.Get(file);
+            return internalCharaDictionary.Get(file);
         }
 
         public static PluginData GetExtendedDataById(ChaFile file, string id)
@@ -47,7 +73,7 @@ namespace ExtensibleSaveFormat
             if (file == null || id == null)
                 return null;
 
-            var dict = internalDictionary.Get(file);
+            var dict = internalCharaDictionary.Get(file);
 
             if (dict != null && dict.TryGetValue(id, out var extendedSection))
                 return extendedSection;
@@ -57,15 +83,31 @@ namespace ExtensibleSaveFormat
 
         public static void SetExtendedDataById(ChaFile file, string id, PluginData extendedFormatData)
         {
-            Dictionary<string, PluginData> chaDictionary = internalDictionary.Get(file);
+            Dictionary<string, PluginData> chaDictionary = internalCharaDictionary.Get(file);
 
             if (chaDictionary == null)
             {
                 chaDictionary = new Dictionary<string, PluginData>();
-                internalDictionary.Set(file, chaDictionary);
+                internalCharaDictionary.Set(file, chaDictionary);
             }
 
             chaDictionary[id] = extendedFormatData;
+        }
+
+        public static PluginData GetSceneExtendedDataById(string id)
+        {
+            if (id == null)
+                return null;
+
+            if (internalSceneDictionary.TryGetValue(id, out var extendedSection))
+                return extendedSection;
+
+            return null;
+        }
+
+        public static void SetSceneExtendedDataById(string id, PluginData extendedFormatData)
+        {
+            internalSceneDictionary[id] = extendedFormatData;
         }
     }
 }

--- a/ExtensibleSaveFormat/Hooks.cs
+++ b/ExtensibleSaveFormat/Hooks.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
 using BepInEx;
+using Studio;
 
 namespace ExtensibleSaveFormat
 {
@@ -19,19 +20,20 @@ namespace ExtensibleSaveFormat
 		{
 			var harmony = HarmonyInstance.Create("com.bepis.bepinex.extensiblesaveformat");
 			harmony.PatchAll(typeof(Hooks));
-		}
+            ManualPatchSceneInfoLoad(harmony); //Manually patching because I can't find a way to automatically patch a method with a ref/out parameter (at least I think this is the issue here).
+        }
 
 
         #region Saving
         private static byte[] currentlySavingData = null;
 
 	    [HarmonyPrefix, HarmonyPatch(typeof(ChaFile), "SaveFile", new[] { typeof(BinaryWriter), typeof(bool) })]
-	    public static void SaveFilePreHook(ChaFile __instance, bool __result, BinaryWriter bw, bool savePng)
+	    public static void ChaFileSaveFilePreHook(ChaFile __instance, bool __result, BinaryWriter bw, bool savePng)
 	    {
-	        ExtendedSave.writeEvent(__instance);
+	        ExtendedSave.cardWriteEvent(__instance);
 	    }
 
-	    public static void SaveFileHook(ChaFile file, BlockHeader header, ref long[] array3)
+	    public static void ChaFileSaveFileHook(ChaFile file, BlockHeader header, ref long[] array3)
 	    {
             Dictionary<string, PluginData> extendedData = ExtendedSave.GetAllExtendedData(file);
 	        if (extendedData == null)
@@ -63,7 +65,7 @@ namespace ExtensibleSaveFormat
 	    }
 
         [HarmonyPostfix, HarmonyPatch(typeof(ChaFile), "SaveFile", new[] { typeof(BinaryWriter), typeof(bool) })]
-        public static void SaveFilePostHook(ChaFile __instance, bool __result, BinaryWriter bw, bool savePng)
+        public static void ChaFileSaveFilePostHook(ChaFile __instance, bool __result, BinaryWriter bw, bool savePng)
         {
             if (!__result || currentlySavingData == null)
                 return;
@@ -72,7 +74,7 @@ namespace ExtensibleSaveFormat
         }
 
         [HarmonyTranspiler, HarmonyPatch(typeof(ChaFile), "SaveFile", new[] { typeof(BinaryWriter), typeof(bool) })]
-        public static IEnumerable<CodeInstruction> SaveFileTranspiler(IEnumerable<CodeInstruction> instructions)
+        public static IEnumerable<CodeInstruction> ChaFileSaveFileTranspiler(IEnumerable<CodeInstruction> instructions)
 	    {
             List<CodeInstruction> newInstructionSet = new List<CodeInstruction>(instructions);
 
@@ -96,16 +98,51 @@ namespace ExtensibleSaveFormat
 	                new CodeInstruction(OpCodes.Ldarg_0), //push the ChaFile instance
 	                new CodeInstruction(OpCodes.Ldloc_S, blockHeaderLocalBuilder), //push the BlockHeader instance 
 	                new CodeInstruction(OpCodes.Ldloca_S, array3LocalBuilder), //push the array3 instance as ref
-                    new CodeInstruction(OpCodes.Call, typeof(Hooks).GetMethod(nameof(SaveFileHook))), //call our hook
+                    new CodeInstruction(OpCodes.Call, typeof(Hooks).GetMethod(nameof(ChaFileSaveFileHook))), //call our hook
 	            });
 
 	        return newInstructionSet;
 	    }
+
+	    [HarmonyTranspiler, HarmonyPatch(typeof(SceneInfo), "Save", new[] {typeof(string)})]
+	    public static IEnumerable<CodeInstruction> SceneInfoSaveTranspiler(IEnumerable<CodeInstruction> instructions)
+	    {
+	        bool set = false;
+	        List<CodeInstruction> instructionsList = instructions.ToList();
+	        for (int i = 0; i < instructionsList.Count; i++)
+	        {
+	            CodeInstruction inst = instructionsList[i];
+	            yield return inst;
+	            if (set == false && inst.opcode == OpCodes.Callvirt && instructionsList[i + 1].opcode == OpCodes.Leave)
+	            {
+	                yield return new CodeInstruction(OpCodes.Ldarg_1);
+	                yield return new CodeInstruction(OpCodes.Ldloc_1);
+	                yield return new CodeInstruction(OpCodes.Call, typeof(Hooks).GetMethod(nameof(SceneInfoSaveHook)));
+	                set = true;
+	            }
+	        }
+	    }
+
+	    public static void SceneInfoSaveHook(string path, BinaryWriter bw)
+	    {
+	        ExtendedSave.sceneWriteEvent(path);
+
+            Dictionary<string, PluginData> extendedData = ExtendedSave.internalSceneDictionary;
+	        if (extendedData == null)
+	            return;
+            byte[] data = MessagePackSerializer.Serialize(extendedData);
+
+            bw.Write(Marker);    //Not super useful
+            bw.Write(Version);   //but kept for consistency
+            bw.Write(data.Length);
+	        bw.Write(data);
+	    }
+
         #endregion
 
         #region Loading
 
-	    public static void LoadFileHook(ChaFile file, BlockHeader header, BinaryReader reader)
+        public static void ChaFileLoadFileHook(ChaFile file, BlockHeader header, BinaryReader reader)
 	    {
 	        var info = header.SearchInfo(Marker);
 
@@ -124,16 +161,16 @@ namespace ExtensibleSaveFormat
 
 	            var dictionary = MessagePackSerializer.Deserialize<Dictionary<string, PluginData>>(data);
 
-	            ExtendedSave.internalDictionary.Set(file, dictionary);
+	            ExtendedSave.internalCharaDictionary.Set(file, dictionary);
 	        }
 	        else
 	        {
-	            ExtendedSave.internalDictionary.Set(file, new Dictionary<string, PluginData>());
+	            ExtendedSave.internalCharaDictionary.Set(file, new Dictionary<string, PluginData>());
 	        }
 	    }
 
         [HarmonyTranspiler, HarmonyPatch(typeof(ChaFile), "LoadFile", new[] { typeof(BinaryReader), typeof(bool), typeof(bool) })]
-        public static IEnumerable<CodeInstruction> LoadFileTranspiler(IEnumerable<CodeInstruction> instructions)
+        public static IEnumerable<CodeInstruction> ChaFileLoadFileTranspiler(IEnumerable<CodeInstruction> instructions)
 	    {
             List<CodeInstruction> newInstructionSet = new List<CodeInstruction>(instructions);
 
@@ -151,14 +188,14 @@ namespace ExtensibleSaveFormat
                     new CodeInstruction(OpCodes.Ldarg_0), //push the ChaFile instance
                     new CodeInstruction(OpCodes.Ldloc_S, blockHeaderLocalBuilder), //push the BlockHeader instance
                     new CodeInstruction(OpCodes.Ldarg_1, blockHeaderLocalBuilder), //push the binaryreader instance
-                        new CodeInstruction(OpCodes.Call, typeof(Hooks).GetMethod(nameof(LoadFileHook))), //call our hook
+                        new CodeInstruction(OpCodes.Call, typeof(Hooks).GetMethod(nameof(ChaFileLoadFileHook))), //call our hook
                 });
 
             return newInstructionSet;
 	    }
 
 	    [HarmonyPostfix, HarmonyPatch(typeof(ChaFile), "LoadFile", new[] { typeof(BinaryReader), typeof(bool), typeof(bool) })]
-	    public static void LoadFilePostHook(ChaFile __instance, bool __result, BinaryReader br, bool noLoadPNG, bool noLoadStatus)
+	    public static void ChaFileLoadFilePostHook(ChaFile __instance, bool __result, BinaryReader br, bool noLoadPNG, bool noLoadStatus)
 	    {
 	        if (!__result)
 	            return;
@@ -183,7 +220,7 @@ namespace ExtensibleSaveFormat
 	                        byte[] bytes = br.ReadBytes(length);
 	                        var dictionary = MessagePackSerializer.Deserialize<Dictionary<string, PluginData>>(bytes);
 
-	                        ExtendedSave.internalDictionary.Set(__instance, dictionary);
+	                        ExtendedSave.internalCharaDictionary.Set(__instance, dictionary);
 	                    }
 	                }
 	                else
@@ -201,14 +238,263 @@ namespace ExtensibleSaveFormat
 	            }
 	        }
 	        
-	        ExtendedSave.readEvent(__instance);
+	        ExtendedSave.cardReadEvent(__instance);
+	    }
+
+
+	    public static void ManualPatchSceneInfoLoad(HarmonyInstance instance)
+	    {
+	        foreach (MethodInfo methodInfo in typeof(SceneInfo).GetMethods())
+	        {
+	            if (methodInfo.Name.Equals("Load") && methodInfo.GetParameters().Length == 2)
+	            {
+	                instance.Patch(methodInfo, null, null, new HarmonyMethod(typeof(Hooks).GetMethod(nameof(SceneInfoLoadTranspiler))));
+	                break;
+	            }
+	        }
+        }
+
+	    //[HarmonyTranspiler, HarmonyPatch(typeof(SceneInfo), "Load", new[] {typeof(string), typeof(Version)})]
+	    public static IEnumerable<CodeInstruction> SceneInfoLoadTranspiler(IEnumerable<CodeInstruction> instructions)
+	    {
+	        bool set = false;
+	        List<CodeInstruction> instructionsList = instructions.ToList();
+	        for (int i = 0; i < instructionsList.Count; i++)
+	        {
+	            CodeInstruction inst = instructionsList[i];
+	            yield return inst;
+	            if (set == false && inst.opcode == OpCodes.Stind_Ref && instructionsList[i + 1].opcode == OpCodes.Leave)
+	            {
+	                yield return new CodeInstruction(OpCodes.Ldarg_1);
+	                yield return new CodeInstruction(OpCodes.Ldloc_1);
+	                yield return new CodeInstruction(OpCodes.Call, typeof(Hooks).GetMethod(nameof(SceneInfoLoadHook)));
+	                set = true;
+	            }
+	        }
+	    }
+
+	    public static void SceneInfoLoadHook(string path, BinaryReader br)
+	    {
+	        ExtendedSave.internalSceneDictionary.Clear();
+
+            try
+	        {
+	            br.ReadString(); //Reading that useless string at the end "【KStudio】"
+
+                string marker = br.ReadString(); 
+	            int version = br.ReadInt32();    
+
+                int length = br.ReadInt32();
+
+                if (marker.Equals(Marker) && length > 0)
+	            {
+	                byte[] bytes = br.ReadBytes(length);
+	                ExtendedSave.internalSceneDictionary = MessagePackSerializer.Deserialize<Dictionary<string, PluginData>>(bytes);
+	            }
+	        }
+	        catch (EndOfStreamException)
+	        {
+	            /* Incomplete/non-existant data */
+	        }
+	        catch (InvalidOperationException)
+	        {
+	            /* Invalid/unexpected deserialized data */
+	        }
+
+	        ExtendedSave.sceneReadEvent(path);
+	    }
+
+
+	    [HarmonyTranspiler, HarmonyPatch(typeof(SceneInfo), "Import", new[] {typeof(string)})]
+	    public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+	    {
+	        bool set = false;
+	        List<CodeInstruction> instructionsList = instructions.ToList();
+	        for (int i = 0; i < instructionsList.Count; i++)
+	        {
+	            CodeInstruction inst = instructionsList[i];
+	            yield return inst;
+	            if (set == false && inst.opcode == OpCodes.Call && instructionsList[i + 1].opcode == OpCodes.Leave)
+	            {
+	                yield return new CodeInstruction(OpCodes.Ldarg_1);
+	                yield return new CodeInstruction(OpCodes.Ldloc_1);
+	                yield return new CodeInstruction(OpCodes.Ldloc_2);
+	                yield return new CodeInstruction(OpCodes.Call, typeof(Hooks).GetMethod(nameof(SceneInfoImportHook)));
+	                set = true;
+	            }
+	        }
+	    }
+
+	    public static void SceneInfoImportHook(string path, BinaryReader br, Version version)
+	    {
+	        {
+	            //Reading useless data
+	            br.ReadInt32();
+	            br.ReadSingle();
+	            br.ReadSingle();
+	            br.ReadSingle();
+	            br.ReadSingle();
+	            br.ReadSingle();
+	            br.ReadSingle();
+	            br.ReadSingle();
+	            br.ReadSingle();
+	            br.ReadSingle();
+	            br.ReadInt32();
+	            br.ReadBoolean();
+	            br.ReadInt32();
+	            if (version.CompareTo(new Version(0, 0, 2)) >= 0)
+	                br.ReadSingle();
+	            if (version.CompareTo(new Version(0, 0, 1)) <= 0)
+	            {
+	                br.ReadBoolean();
+	                br.ReadSingle();
+	                br.ReadString();
+	            }
+	            if (version.CompareTo(new Version(0, 0, 2)) >= 0)
+	            {
+	                br.ReadBoolean();
+	                br.ReadString();
+	                br.ReadSingle();
+	            }
+	            br.ReadBoolean();
+	            br.ReadSingle();
+	            br.ReadSingle();
+	            if (version.CompareTo(new Version(0, 0, 2)) >= 0)
+	                br.ReadSingle();
+	            if (version.CompareTo(new Version(0, 0, 1)) <= 0)
+	                br.ReadBoolean();
+	            br.ReadBoolean();
+	            br.ReadSingle();
+	            br.ReadSingle();
+	            br.ReadBoolean();
+	            if (version.CompareTo(new Version(0, 0, 1)) <= 0)
+	                br.ReadSingle();
+	            br.ReadBoolean();
+	            if (version.CompareTo(new Version(0, 0, 2)) >= 0)
+	            {
+	                br.ReadString();
+	                br.ReadSingle();
+	                br.ReadSingle();
+	            }
+	            br.ReadBoolean();
+	            if (version.CompareTo(new Version(0, 0, 2)) >= 0)
+	            {
+	                br.ReadString();
+	                br.ReadString();
+	            }
+	            if (version.CompareTo(new Version(0, 0, 4)) >= 0)
+	                br.ReadInt32();
+	            if (version.CompareTo(new Version(0, 0, 2)) >= 0)
+	                br.ReadBoolean();
+	            if (version.CompareTo(new Version(0, 0, 4)) >= 0)
+	            {
+	                br.ReadBoolean();
+	                br.ReadBoolean();
+	                br.ReadSingle();
+	                br.ReadString();
+	            }
+	            if (version.CompareTo(new Version(0, 0, 5)) >= 0)
+	            {
+	                br.ReadSingle();
+	                br.ReadInt32();
+	                br.ReadSingle();
+	            }
+
+	            int num = br.ReadInt32();
+	            br.ReadSingle();
+	            br.ReadSingle();
+	            br.ReadSingle();
+	            br.ReadSingle();
+	            br.ReadSingle();
+	            br.ReadSingle();
+	            if (num == 1)
+	                br.ReadSingle();
+	            else
+	            {
+	                br.ReadSingle();
+	                br.ReadSingle();
+	                br.ReadSingle();
+	            }
+	            br.ReadSingle();
+	            for (int j = 0; j < 10; j++)
+	            {
+	                num = br.ReadInt32();
+	                br.ReadSingle();
+	                br.ReadSingle();
+	                br.ReadSingle();
+	                br.ReadSingle();
+	                br.ReadSingle();
+	                br.ReadSingle();
+	                if (num == 1)
+	                    br.ReadSingle();
+	                else
+	                {
+	                    br.ReadSingle();
+	                    br.ReadSingle();
+	                    br.ReadSingle();
+	                }
+	                br.ReadSingle();
+	            }
+	            br.ReadString();
+	            br.ReadSingle();
+	            br.ReadSingle();
+	            br.ReadSingle();
+	            br.ReadBoolean();
+
+	            br.ReadString();
+	            br.ReadSingle();
+	            br.ReadSingle();
+	            br.ReadSingle();
+	            br.ReadBoolean();
+
+	            br.ReadInt32();
+	            br.ReadInt32();
+	            br.ReadBoolean();
+
+	            br.ReadInt32();
+	            br.ReadInt32();
+	            br.ReadBoolean();
+
+	            br.ReadInt32();
+	            br.ReadString();
+	            br.ReadBoolean();
+	            br.ReadString();
+	            br.ReadString();
+	            br.ReadString();
+	            br.ReadBytes(16);
+	        }
+
+            ExtendedSave.internalSceneDictionary.Clear();;
+            try
+            {
+                string marker = br.ReadString();
+                int ver = br.ReadInt32();
+
+                int length = br.ReadInt32();
+
+                if (marker.Equals(Marker) && length > 0)
+	            {
+	                byte[] bytes = br.ReadBytes(length);
+	                ExtendedSave.internalSceneDictionary = MessagePackSerializer.Deserialize<Dictionary<string, PluginData>>(bytes);
+	            }
+	        }
+	        catch (EndOfStreamException)
+	        {
+	            /* Incomplete/non-existant data */
+	        }
+	        catch (InvalidOperationException)
+	        {
+	            /* Invalid/unexpected deserialized data */
+	        }
+
+	        ExtendedSave.sceneImportEvent(path);
 	    }
 	    #endregion
 
-        
-	    #region Helper
 
-	    public static bool CheckCallVirtName(CodeInstruction instruction, string name)
+        #region Helper
+
+        public static bool CheckCallVirtName(CodeInstruction instruction, string name)
 	    {
 	        return instruction.opcode == OpCodes.Callvirt &&
 	               //need to do reflection fuckery here because we can't access MonoMethod which is the operand type, not MehtodInfo like normal reflection

--- a/ExtensibleSaveFormat/Hooks.cs
+++ b/ExtensibleSaveFormat/Hooks.cs
@@ -20,7 +20,6 @@ namespace ExtensibleSaveFormat
 		{
 			var harmony = HarmonyInstance.Create("com.bepis.bepinex.extensiblesaveformat");
 			harmony.PatchAll(typeof(Hooks));
-            ManualPatchSceneInfoLoad(harmony); //Manually patching because I can't find a way to automatically patch a method with a ref/out parameter (at least I think this is the issue here).
         }
 
 
@@ -241,20 +240,7 @@ namespace ExtensibleSaveFormat
 	        ExtendedSave.cardReadEvent(__instance);
 	    }
 
-
-	    public static void ManualPatchSceneInfoLoad(HarmonyInstance instance)
-	    {
-	        foreach (MethodInfo methodInfo in typeof(SceneInfo).GetMethods())
-	        {
-	            if (methodInfo.Name.Equals("Load") && methodInfo.GetParameters().Length == 2)
-	            {
-	                instance.Patch(methodInfo, null, null, new HarmonyMethod(typeof(Hooks).GetMethod(nameof(SceneInfoLoadTranspiler))));
-	                break;
-	            }
-	        }
-        }
-
-	    //[HarmonyTranspiler, HarmonyPatch(typeof(SceneInfo), "Load", new[] {typeof(string), typeof(Version)})]
+	    [HarmonyTranspiler, HarmonyPatch(typeof(SceneInfo), "Load", new[] {typeof(string), typeof(Version)}, new []{1})]
 	    public static IEnumerable<CodeInstruction> SceneInfoLoadTranspiler(IEnumerable<CodeInstruction> instructions)
 	    {
 	        bool set = false;


### PR DESCRIPTION
Hooks and callbacks were implemented when a scene is loaded/imported/saved in CharaStudio.
Renaming of some already existing functions had to be done to keep readability and logic in the code.
Additional data is added at the end of the file, after everything else was written.
MessagePackSerializer was used as well in this case to be able to keep using the already existing class "PluginData".
Manual patching had to be done for scene loading because I didn't find a way to automatically patch a function with an out/ref parameter.

Sorry I made a typo in the name of the commit.