### PR TITLE
Fire OnLevelWasLoaded on actual level load in IPALoader

### DIFF
--- a/IPALoader/IPAPlugin.cs
+++ b/IPALoader/IPAPlugin.cs
@@ -21,6 +21,9 @@ namespace IPALoader
 
             SceneManager.sceneLoaded += (scene, mode) =>
             {
+                if (mode != LoadSceneMode.Single)
+                    return;
+
                 BasePlugin.OnLevelWasLoaded(scene.buildIndex);
                 init = true;
             };
@@ -44,8 +47,8 @@ namespace IPALoader
 
         void LateUpdate()
         {
-            if (BasePlugin is IEnhancedPlugin)
-                ((IEnhancedPlugin)BasePlugin).OnLateUpdate();
+            if (BasePlugin is IEnhancedPlugin plugin)
+                plugin.OnLateUpdate();
         }
 
         void FixedUpdate()


### PR DESCRIPTION
Originally, `IPlugin.OnLevelWasLoaded` is tied to `MonoBehaviour.OnLevelWasLoaded` which only fires when the level is actually reloaded. In newer versions of Unity this seems to be equivalent of loading a scene with `LoadSceneMode.Single` as the load mode.

Since this is unaccounted for in IPALoader, `IPlugin.OnLevelWasLoaded` is being fired

* on any scene change -- even if the level itself wasn't changed
* on scene unloads (with scene level -1)

This causes some IPA plugins (most notably KoikPlugin) prematurely unloading itself and not functioning the same way as in normal IPA install.

This fix simply makes `IPlugin.OnLevelWasLoaded` fire on only full scene loads, simulating the original behaviour of the method. As a result, compatibility with IPA plugins should increase.