### PR TITLE
Fix for hard mod accessories loading with sideloader mods

### DIFF
--- a/Sideloader/AutoResolver/StructReference.cs
+++ b/Sideloader/AutoResolver/StructReference.cs
@@ -469,22 +469,91 @@ namespace Sideloader.AutoResolver
         {
             string prefix = $"{nameof(ChaFileAccessory)}.{nameof(ChaFileAccessory.PartsInfo)}";
 
-            var baseProperties = new List<CategoryProperty>
-            {
-                new CategoryProperty(CategoryNo.ao_none , "id", prefix),
-                new CategoryProperty(CategoryNo.ao_hair , "id", prefix),
-                new CategoryProperty(CategoryNo.ao_head , "id", prefix),
-                new CategoryProperty(CategoryNo.ao_face , "id", prefix),
-                new CategoryProperty(CategoryNo.ao_neck , "id", prefix),
-                new CategoryProperty(CategoryNo.ao_body , "id", prefix),
-                new CategoryProperty(CategoryNo.ao_waist , "id", prefix),
-                new CategoryProperty(CategoryNo.ao_leg , "id", prefix),
-                new CategoryProperty(CategoryNo.ao_arm , "id", prefix),
-                new CategoryProperty(CategoryNo.ao_hand , "id", prefix),
-                new CategoryProperty(CategoryNo.ao_kokan , "id", prefix)
-            };
+            //var baseProperties = new List<CategoryProperty>
+            //{
+            //    new CategoryProperty(CategoryNo.ao_none , "id", prefix),
+            //    new CategoryProperty(CategoryNo.ao_hair , "id", prefix),
+            //    new CategoryProperty(CategoryNo.ao_head , "id", prefix),
+            //    new CategoryProperty(CategoryNo.ao_face , "id", prefix),
+            //    new CategoryProperty(CategoryNo.ao_neck , "id", prefix),
+            //    new CategoryProperty(CategoryNo.ao_body , "id", prefix),
+            //    new CategoryProperty(CategoryNo.ao_waist , "id", prefix),
+            //    new CategoryProperty(CategoryNo.ao_leg , "id", prefix),
+            //    new CategoryProperty(CategoryNo.ao_arm , "id", prefix),
+            //    new CategoryProperty(CategoryNo.ao_hand , "id", prefix),
+            //    new CategoryProperty(CategoryNo.ao_kokan , "id", prefix)
+            //};
 
-            var generatedProperties = GeneratePropertyInfoDictionary(typeof(ChaFileAccessory.PartsInfo), baseProperties, prefix);
+            //var generatedProperties = GeneratePropertyInfoDictionary(typeof(ChaFileAccessory.PartsInfo), baseProperties, prefix);
+
+            var generatedProperties = new Dictionary<CategoryProperty, StructValue<int>>();
+
+            generatedProperties.Add(
+                new CategoryProperty(CategoryNo.ao_none, "AccessoryNone", prefix),
+                new StructValue<int>(
+                    (obj, value) => { ((ChaFileAccessory.PartsInfo)obj).id = value; },
+                    (obj) => ((ChaFileAccessory.PartsInfo)obj).id));
+
+            generatedProperties.Add(
+                new CategoryProperty(CategoryNo.ao_hair, "AccessoryHair", prefix),
+                new StructValue<int>(
+                    (obj, value) => { ((ChaFileAccessory.PartsInfo)obj).id = value; },
+                    (obj) => ((ChaFileAccessory.PartsInfo)obj).id));
+
+            generatedProperties.Add(
+                new CategoryProperty(CategoryNo.ao_head, "AccessoryHead", prefix),
+                new StructValue<int>(
+                    (obj, value) => { ((ChaFileAccessory.PartsInfo)obj).id = value; },
+                    (obj) => ((ChaFileAccessory.PartsInfo)obj).id));
+
+            generatedProperties.Add(
+                new CategoryProperty(CategoryNo.ao_face, "AccessoryFace", prefix),
+                new StructValue<int>(
+                    (obj, value) => { ((ChaFileAccessory.PartsInfo)obj).id = value; },
+                    (obj) => ((ChaFileAccessory.PartsInfo)obj).id));
+
+            generatedProperties.Add(
+                new CategoryProperty(CategoryNo.ao_neck, "AccessoryNeck", prefix),
+                new StructValue<int>(
+                    (obj, value) => { ((ChaFileAccessory.PartsInfo)obj).id = value; },
+                    (obj) => ((ChaFileAccessory.PartsInfo)obj).id));
+
+            generatedProperties.Add(
+                new CategoryProperty(CategoryNo.ao_body, "AccessoryBody", prefix),
+                new StructValue<int>(
+                    (obj, value) => { ((ChaFileAccessory.PartsInfo)obj).id = value; },
+                    (obj) => ((ChaFileAccessory.PartsInfo)obj).id));
+
+            generatedProperties.Add(
+                new CategoryProperty(CategoryNo.ao_waist, "AccessoryWaist", prefix),
+                new StructValue<int>(
+                    (obj, value) => { ((ChaFileAccessory.PartsInfo)obj).id = value; },
+                    (obj) => ((ChaFileAccessory.PartsInfo)obj).id));
+
+            generatedProperties.Add(
+                new CategoryProperty(CategoryNo.ao_leg, "AccessoryLeg", prefix),
+                new StructValue<int>(
+                    (obj, value) => { ((ChaFileAccessory.PartsInfo)obj).id = value; },
+                    (obj) => ((ChaFileAccessory.PartsInfo)obj).id));
+
+            generatedProperties.Add(
+                new CategoryProperty(CategoryNo.ao_arm, "AccessoryArm", prefix),
+                new StructValue<int>(
+                    (obj, value) => { ((ChaFileAccessory.PartsInfo)obj).id = value; },
+                    (obj) => ((ChaFileAccessory.PartsInfo)obj).id));
+
+            generatedProperties.Add(
+                new CategoryProperty(CategoryNo.ao_hand, "AccessoryHand", prefix),
+                new StructValue<int>(
+                    (obj, value) => { ((ChaFileAccessory.PartsInfo)obj).id = value; },
+                    (obj) => ((ChaFileAccessory.PartsInfo)obj).id));
+
+            generatedProperties.Add(
+                new CategoryProperty(CategoryNo.ao_kokan, "AccessoryKokan", prefix),
+                new StructValue<int>(
+                    (obj, value) => { ((ChaFileAccessory.PartsInfo)obj).id = value; },
+                    (obj) => ((ChaFileAccessory.PartsInfo)obj).id));
+
 
             return generatedProperties;
         }

--- a/Sideloader/AutoResolver/UniversalAutoResolver.cs
+++ b/Sideloader/AutoResolver/UniversalAutoResolver.cs
@@ -15,44 +15,80 @@ namespace Sideloader.AutoResolver
 
         public static void ResolveStructure(Dictionary<CategoryProperty, StructValue<int>> propertyDict, object structure, IEnumerable<ResolveInfo> extInfo, string propertyPrefix = "")
         {
-			void CompatibilityResolve(KeyValuePair<CategoryProperty, StructValue<int>> kv)
-	        {
-		        //check if it's a vanilla item
-		        if (!ResourceRedirector.ListLoader.InternalDataList[kv.Key.Category]
-			        .ContainsKey(kv.Value.GetMethod(structure)))
-		        {
-			        //the property does not have external slot information
-			        //check if we have a corrosponding item for backwards compatbility
-			        var intResolve = LoadedResolutionInfo.FirstOrDefault(x => x.Property == kv.Key.ToString()
-			                                                                  && x.Slot == kv.Value.GetMethod(structure));
+            void CompatibilityResolve(KeyValuePair<CategoryProperty, StructValue<int>> kv)
+            {
+                //check if it's a vanilla item
+                if (!ResourceRedirector.ListLoader.InternalDataList[kv.Key.Category].ContainsKey(kv.Value.GetMethod(structure)))
+                {
+                    //the property does not have external slot information
+                    //check if we have a corrosponding item for backwards compatbility
 
-			        if (intResolve != null)
-			        {
-				        //found a match
-				        Logger.Log(LogLevel.Info, $"[UAR] Compatibility resolving {intResolve.Property} from slot {kv.Value.GetMethod(structure)} to slot {intResolve.LocalSlot}");
+                    //For accessories, only check the appropriate category
+                    if (propertyPrefix.Contains("accessory"))
+                    {
+                        ChaFileAccessory.PartsInfo AccessoryInfo = (ChaFileAccessory.PartsInfo)structure;
 
-				        kv.Value.SetMethod(structure, intResolve.LocalSlot);
-			        }
-			        //otherwise ignore if not found
-		        }
-		        else
-		        {
-			        //not resolving since we prioritize vanilla items over modded items
-			        //BepInLogger.Log($"[UAR] Not resolving item due to vanilla ID range");
-			        //log commented out because it causes too much spam
-		        }
-	        }
+                        //This is so fucking bad, please kill me.
+                        if ((kv.Key.ToString() == "ChaFileAccessory.PartsInfo.AccessoryNone") && ((int)AccessoryInfo.type == 120))
+                            Logger.Log(LogLevel.Debug, "Matched Accessory");
+                        else if ((kv.Key.ToString() == "ChaFileAccessory.PartsInfo.AccessoryHair") && ((int)AccessoryInfo.type == 121))
+                            Logger.Log(LogLevel.Debug, "Matched Accessory");
+                        else if ((kv.Key.ToString() == "ChaFileAccessory.PartsInfo.AccessoryHead") && ((int)AccessoryInfo.type == 122))
+                            Logger.Log(LogLevel.Debug, "Matched Accessory");
+                        else if ((kv.Key.ToString() == "ChaFileAccessory.PartsInfo.AccessoryFace") && ((int)AccessoryInfo.type == 123))
+                            Logger.Log(LogLevel.Debug, "Matched Accessory");
+                        else if ((kv.Key.ToString() == "ChaFileAccessory.PartsInfo.AccessoryNeck") && ((int)AccessoryInfo.type == 124))
+                            Logger.Log(LogLevel.Debug, "Matched Accessory");
+                        else if ((kv.Key.ToString() == "ChaFileAccessory.PartsInfo.AccessoryBody") && ((int)AccessoryInfo.type == 125))
+                            Logger.Log(LogLevel.Debug, "Matched Accessory");
+                        else if ((kv.Key.ToString() == "ChaFileAccessory.PartsInfo.AccessoryWaist") && ((int)AccessoryInfo.type == 126))
+                            Logger.Log(LogLevel.Debug, "Matched Accessory");
+                        else if ((kv.Key.ToString() == "ChaFileAccessory.PartsInfo.AccessoryLeg") && ((int)AccessoryInfo.type == 127))
+                            Logger.Log(LogLevel.Debug, "Matched Accessory");
+                        else if ((kv.Key.ToString() == "ChaFileAccessory.PartsInfo.AccessoryArm") && ((int)AccessoryInfo.type == 128))
+                            Logger.Log(LogLevel.Debug, "Matched Accessory");
+                        else if ((kv.Key.ToString() == "ChaFileAccessory.PartsInfo.AccessoryHand") && ((int)AccessoryInfo.type == 129))
+                            Logger.Log(LogLevel.Debug, "Matched Accessory");
+                        else if ((kv.Key.ToString() == "ChaFileAccessory.PartsInfo.AccessoryKokan") && ((int)AccessoryInfo.type == 130))
+                            Logger.Log(LogLevel.Debug, "Matched Accessory");
+                        else
+                            return;
+                    }
 
-			HashSet<string> keyHashset = new HashSet<string>();
+                    var intResolve = LoadedResolutionInfo.FirstOrDefault(x => x.Property == kv.Key.ToString()
+                                                                              && x.Slot == kv.Value.GetMethod(structure));
+
+                    if (intResolve != null)
+                    {
+                        //found a match
+                        Logger.Log(LogLevel.Info, $"[UAR] Compatibility resolving {intResolve.Property} from slot {kv.Value.GetMethod(structure)} to slot {intResolve.LocalSlot}");
+
+                        kv.Value.SetMethod(structure, intResolve.LocalSlot);
+                    }
+                    else
+                    {
+                        //No match was found
+                        Logger.Log(LogLevel.Info, $"Unable to locate mod with ID: {kv.Value.GetMethod(structure)} in slot {kv.Key.ToString()}");
+                    }
+                }
+                else
+                {
+                    //not resolving since we prioritize vanilla items over modded items
+                    //BepInLogger.Log($"[UAR] Not resolving item due to vanilla ID range");
+                    //log commented out because it causes too much spam
+                }
+            }
+
+            HashSet<string> keyHashset = new HashSet<string>();
 
             foreach (var kv in propertyDict)
             {
-	            string property = $"{propertyPrefix}{kv.Key}";
+                string property = $"{propertyPrefix}{kv.Key}";
 
-	            if (keyHashset.Contains(property))
-		            continue;
+                if (keyHashset.Contains(property))
+                    continue;
 
-	            keyHashset.Add(property);
+                keyHashset.Add(property);
 
                 if (extInfo != null)
                 {
@@ -70,36 +106,36 @@ namespace Sideloader.AutoResolver
 
                             kv.Value.SetMethod(structure, intResolve.LocalSlot);
                         }
-                        else 
+                        else
                         {
-							//we didn't find a match, check if we have the same GUID loaded
+                            //we didn't find a match, check if we have the same GUID loaded
 
-	                        if (LoadedResolutionInfo.Any(x => x.GUID == extResolve.GUID))
-							{
-								//we have the GUID loaded, so the user has an outdated mod
-								Logger.Log(LogLevel.Warning | LogLevel.Message, $"[UAR] WARNING! Outdated mod detected! [{extResolve.GUID}]");
-							}
-							else
-							{
-								//did not find a match, we don't have the mod
-								Logger.Log(LogLevel.Warning | LogLevel.Message, $"[UAR] WARNING! Missing mod detected! [{extResolve.GUID}]");
-							}
+                            if (LoadedResolutionInfo.Any(x => x.GUID == extResolve.GUID))
+                            {
+                                //we have the GUID loaded, so the user has an outdated mod
+                                Logger.Log(LogLevel.Warning | LogLevel.Message, $"[UAR] WARNING! Outdated mod detected! [{extResolve.GUID}]");
+                            }
+                            else
+                            {
+                                //did not find a match, we don't have the mod
+                                Logger.Log(LogLevel.Warning | LogLevel.Message, $"[UAR] WARNING! Missing mod detected! [{extResolve.GUID}]");
+                            }
 
-	                        kv.Value.SetMethod(structure, 999999); //set to an invalid ID
+                            kv.Value.SetMethod(structure, 999999); //set to an invalid ID
                         }
                     }
-                    else if (UnityEngine.Event.current.alt)
+                    else //if (UnityEngine.Event.current.alt)
                     {
-						CompatibilityResolve(kv);
+                        CompatibilityResolve(kv);
                     }
                 }
                 else
                 {
-					CompatibilityResolve(kv);
+                    CompatibilityResolve(kv);
                 }
             }
         }
-        
+
         private static int CurrentSlotID = 100000000;
 
         public static void GenerateResolutionInfo(Manifest manifest, ChaListData data)
@@ -129,16 +165,16 @@ namespace Sideloader.AutoResolver
                         LocalSlot = newSlot,
                         Property = propertyKey.ToString()
                     });
-                    
+
                     //BepInLogger.Log($"LOADED COUNT {LoadedResolutionInfo.Count}");
                 }
 
                 kv.Value[0] = newSlot.ToString();
             }
 
-	        //BepInLogger.Log($"Internal info count: {LoadedResolutionInfo.Count}");
-	        //foreach (ResolveInfo info in LoadedResolutionInfo)
-	        //    BepInLogger.Log($"Internal info: {info.ModID} : {info.Property} : {info.Slot}");
+            //BepInLogger.Log($"Internal info count: {LoadedResolutionInfo.Count}");
+            //foreach (ResolveInfo info in LoadedResolutionInfo)
+            //    BepInLogger.Log($"Internal info: {info.ModID} : {info.Property} : {info.Slot}");
         }
     }
 }


### PR DESCRIPTION
Accessories had to be restructured so that each category has a unique name. During the compatibility resolving process, accessories have to be prevented from attempting to load from categories other than their own.

Because accessories now have a different name, cards made on this version of sideloader will not be backwards compatible with previous versions of sideloader and sideloader accessories will fail to load. Cards made on previous sideloader versions SHOULD be compatible with this version because compatibility resolving will automatically handle it using the accessory's ID.