### PR TITLE
Speed up character saving and loading times

### DIFF
--- a/Sideloader/AutoResolver/Hooks.cs
+++ b/Sideloader/AutoResolver/Hooks.cs
@@ -11,232 +11,271 @@ using Illusion.Extensions;
 
 namespace Sideloader.AutoResolver
 {
-	public static class Hooks
-	{
-		public static void InstallHooks()
-		{
-			ExtendedSave.CardBeingLoaded += ExtendedCardLoad;
-			ExtendedSave.CardBeingSaved += ExtendedCardSave;
+    public static class Hooks
+    {
+        public static void InstallHooks()
+        {
+            ExtendedSave.CardBeingLoaded += ExtendedCardLoad;
+            ExtendedSave.CardBeingSaved += ExtendedCardSave;
 
-			ExtendedSave.CoordinateBeingLoaded += ExtendedCoordinateLoad;
-			ExtendedSave.CoordinateBeingSaved += ExtendedCoordinateSave;
+            ExtendedSave.CoordinateBeingLoaded += ExtendedCoordinateLoad;
+            ExtendedSave.CoordinateBeingSaved += ExtendedCoordinateSave;
 
-			var harmony = HarmonyInstance.Create("com.bepis.bepinex.sideloader.universalautoresolver");
-			harmony.PatchAll(typeof(Hooks));
-		}
+            var harmony = HarmonyInstance.Create("com.bepis.bepinex.sideloader.universalautoresolver");
+            harmony.PatchAll(typeof(Hooks));
+        }
 
-		public static bool IsResolving { get; set; } = true;
+        public static bool IsResolving { get; set; } = true;
 
-		#region ChaFile
+        #region ChaFile
 
-		private static void IterateCardPrefixes(Action<Dictionary<CategoryProperty, StructValue<int>>, object, IEnumerable<ResolveInfo>, string> action, ChaFile file, IEnumerable<ResolveInfo> extInfo)
-		{
-			action(StructReference.ChaFileFaceProperties, file.custom.face, extInfo, "");
-			action(StructReference.ChaFileBodyProperties, file.custom.body, extInfo, "");
-			action(StructReference.ChaFileHairProperties, file.custom.hair, extInfo, "");
+        private static void IterateCardPrefixes(Action<Dictionary<CategoryProperty, StructValue<int>>, object, IEnumerable<ResolveInfo>, string> action, ChaFile file, IEnumerable<ResolveInfo> extInfo)
+        {
+            action(StructReference.ChaFileFaceProperties, file.custom.face, extInfo, "");
+            action(StructReference.ChaFileBodyProperties, file.custom.body, extInfo, "");
+            action(StructReference.ChaFileHairProperties, file.custom.hair, extInfo, "");
             action(StructReference.ChaFileMakeupProperties, file.custom.face.baseMakeup, extInfo, "");
 
             for (int i = 0; i < file.coordinate.Length; i++)
-			{
-				var coordinate = file.coordinate[i];
-				string prefix = $"outfit{i}.";
-                
-				action(StructReference.ChaFileClothesProperties, coordinate.clothes, extInfo, prefix);
+            {
+                var coordinate = file.coordinate[i];
+                string prefix = $"outfit{i}.";
+
+                action(StructReference.ChaFileClothesProperties, coordinate.clothes, extInfo, prefix);
 
                 for (int acc = 0; acc < coordinate.accessory.parts.Length; acc++)
-				{
-					string accPrefix = $"{prefix}accessory{acc}.";
+                {
+                    string accPrefix = $"{prefix}accessory{acc}.";
 
-					action(StructReference.ChaFileAccessoryPartsInfoProperties, coordinate.accessory.parts[acc], extInfo, accPrefix);
-				}
-			}
-		}
-
-		private static void ExtendedCardLoad(ChaFile file)
-		{
-			if (!IsResolving)
-				return;
-			
-			Logger.Log(LogLevel.Debug, $"Loading card [{file.charaFileName}]");
-
-			var extData = ExtendedSave.GetExtendedDataById(file, UniversalAutoResolver.UARExtID);
-			List<ResolveInfo> extInfo;
-
-			if (extData == null || !extData.data.ContainsKey("info"))
-			{
-				Logger.Log(LogLevel.Debug, "No sideloader marker found");
-				extInfo = null;
-			}
-			else
-			{
-				var tmpExtInfo = (object[])extData.data["info"];
-				extInfo = tmpExtInfo.Select(x => ResolveInfo.Unserialize((byte[])x)).ToList();
-				
-				Logger.Log(LogLevel.Debug, "Sideloader marker found");
-				Logger.Log(LogLevel.Debug, $"External info count: {extInfo.Count}");
-				foreach (ResolveInfo info in extInfo)
-					Logger.Log(LogLevel.Debug, $"External info: {info.GUID} : {info.Property} : {info.Slot}");
-			}
-
-			IterateCardPrefixes(UniversalAutoResolver.ResolveStructure, file, extInfo);
+                    action(StructReference.ChaFileAccessoryPartsInfoProperties, coordinate.accessory.parts[acc], extInfo, accPrefix);
+                }
+            }
         }
 
-		private static void ExtendedCardSave(ChaFile file)
-		{
-			List<ResolveInfo> resolutionInfo = new List<ResolveInfo>();
+        private static void ExtendedCardLoad(ChaFile file)
+        {
+            if (!IsResolving)
+                return;
 
-		    void IterateStruct(Dictionary<CategoryProperty, StructValue<int>> dict, object obj, IEnumerable<ResolveInfo> extInfo, string propertyPrefix = "")
-		    {
-		        foreach (var kv in dict)
-		        {
-		            int slot = kv.Value.GetMethod(obj);
+            Logger.Log(LogLevel.Debug, $"Loading card [{file.charaFileName}]");
 
-		            var info = UniversalAutoResolver.LoadedResolutionInfo.FirstOrDefault(x => x.Property == kv.Key.ToString() &&
-		                                                                                      x.LocalSlot == slot);
+            var extData = ExtendedSave.GetExtendedDataById(file, UniversalAutoResolver.UARExtID);
+            List<ResolveInfo> extInfo;
 
-			        if (info == null) 
-				        continue;
+            if (extData == null || !extData.data.ContainsKey("info"))
+            {
+                Logger.Log(LogLevel.Debug, "No sideloader marker found");
+                extInfo = null;
+            }
+            else
+            {
+                var tmpExtInfo = (object[])extData.data["info"];
+                extInfo = tmpExtInfo.Select(x => ResolveInfo.Unserialize((byte[])x)).ToList();
 
+                Logger.Log(LogLevel.Debug, "Sideloader marker found");
+                Logger.Log(LogLevel.Debug, $"External info count: {extInfo.Count}");
+                foreach (ResolveInfo info in extInfo)
+                    Logger.Log(LogLevel.Debug, $"External info: {info.GUID} : {info.Property} : {info.Slot}");
+            }
 
-			        var newInfo = info.DeepCopy();
-			        newInfo.Property = $"{propertyPrefix}{newInfo.Property}";
+            IterateCardPrefixes(UniversalAutoResolver.ResolveStructure, file, extInfo);
+        }
 
-			        kv.Value.SetMethod(obj, newInfo.Slot);
+        private static void ExtendedCardSave(ChaFile file)
+        {
+            List<ResolveInfo> resolutionInfo = new List<ResolveInfo>();
 
-			        resolutionInfo.Add(newInfo);
-		        }
-		    }
+            void IterateStruct(Dictionary<CategoryProperty, StructValue<int>> dict, object obj, IEnumerable<ResolveInfo> extInfo, string propertyPrefix = "")
+            {
+                foreach (var kv in dict)
+                {
+                    int slot = kv.Value.GetMethod(obj);
 
-			IterateCardPrefixes(IterateStruct, file, null);
+                    //No need to attempt a resolution info lookup for empty accessory slots and pattern slots
+                    if (slot == 0)
+                        continue;
 
-            ExtendedSave.SetExtendedDataById(file, UniversalAutoResolver.UARExtID, new PluginData
-			{
-				data = new Dictionary<string, object>
-				{
-					["info"] = resolutionInfo.Select(x => x.Serialize()).ToList()
-				}
-			});
-		}
+                    //Check if it's a vanilla item
+                    if (slot < 100000000)
+                        if (ResourceRedirector.ListLoader.InternalDataList[kv.Key.Category].ContainsKey(slot))
+                            continue;
 
-		[HarmonyPostfix, HarmonyPatch(typeof(ChaFile), "SaveFile", new[] { typeof(BinaryWriter), typeof(bool) })]
-		public static void ChaFileSaveFilePostHook(ChaFile __instance, bool __result, BinaryWriter bw, bool savePng)
-		{
-			Logger.Log(LogLevel.Debug, $"Reloading card [{__instance.charaFileName}]");
+                    //For accessories, make sure we're checking the appropriate category
+                    if (kv.Key.Category.ToString().Contains("ao_"))
+                    {
+                        ChaFileAccessory.PartsInfo AccessoryInfo = (ChaFileAccessory.PartsInfo)obj;
 
-			var extData = ExtendedSave.GetExtendedDataById(__instance, UniversalAutoResolver.UARExtID);
+                        if ((int)kv.Key.Category != AccessoryInfo.type)
+                        {
+                            //If the current category does not match the accessory's category do not attempt a resolution info lookup
+                            continue;
+                        }
+                    }
 
-			var tmpExtInfo = (List<byte[]>) extData.data["info"];
-			var extInfo = tmpExtInfo.Select(ResolveInfo.Unserialize).ToList();
+                    var info = UniversalAutoResolver.LoadedResolutionInfo.FirstOrDefault(x => x.Property == kv.Key.ToString() &&
+                                                                                              x.LocalSlot == slot);
 
-			Logger.Log(LogLevel.Debug, $"External info count: {extInfo.Count}");
-			foreach (ResolveInfo info in extInfo)
-				Logger.Log(LogLevel.Debug, $"External info: {info.GUID} : {info.Property} : {info.Slot}");
+                    if (info == null)
+                        continue;
 
-			void ResetStructResolveStructure(Dictionary<CategoryProperty, StructValue<int>> propertyDict, object structure, IEnumerable<ResolveInfo> extInfo2, string propertyPrefix = "")
-			{
-				foreach (var kv in propertyDict)
-				{
-					var extResolve = extInfo.FirstOrDefault(x => x.Property == $"{propertyPrefix}{kv.Key.ToString()}");
+                    var newInfo = info.DeepCopy();
+                    newInfo.Property = $"{propertyPrefix}{newInfo.Property}";
 
-					if (extResolve != null)
-					{
-						kv.Value.SetMethod(structure, extResolve.LocalSlot);
+                    kv.Value.SetMethod(obj, newInfo.Slot);
 
-						Logger.Log(LogLevel.Debug, $"[UAR] Resetting {extResolve.GUID}:{extResolve.Property} to internal slot {extResolve.LocalSlot}");
-					}
-				}
-			}
+                    resolutionInfo.Add(newInfo);
+                }
+            }
 
-			IterateCardPrefixes(ResetStructResolveStructure, __instance, extInfo);
-		}
-
-		#endregion
-
-		#region ChaFileCoordinate
-
-		private static void IterateCoordinatePrefixes(Action<Dictionary<CategoryProperty, StructValue<int>>, object, IEnumerable<ResolveInfo>, string> action, ChaFileCoordinate coordinate, IEnumerable<ResolveInfo> extInfo)
-		{
-			action(StructReference.ChaFileClothesProperties, coordinate.clothes, extInfo, "");
-			action(StructReference.ChaFileMakeupProperties, coordinate.makeup, extInfo, "");
-
-			for (int acc = 0; acc < coordinate.accessory.parts.Length; acc++)
-			{
-				string accPrefix = $"accessory{acc}.";
-
-				action(StructReference.ChaFileAccessoryPartsInfoProperties, coordinate.accessory.parts[acc], extInfo, accPrefix);
-			}
-		}
-
-		private static void ExtendedCoordinateLoad(ChaFileCoordinate file)
-		{
-			if (!IsResolving)
-				return;
-
-			Logger.Log(LogLevel.Debug, $"Loading coordinate [{file.coordinateName}]");
-
-			var extData = ExtendedSave.GetExtendedDataById(file, UniversalAutoResolver.UARExtID);
-			List<ResolveInfo> extInfo;
-
-			if (extData == null || !extData.data.ContainsKey("info"))
-			{
-				Logger.Log(LogLevel.Debug, "No sideloader marker found");
-				extInfo = null;
-			}
-			else
-			{
-				var tmpExtInfo = (object[])extData.data["info"];
-				extInfo = tmpExtInfo.Select(x => ResolveInfo.Unserialize((byte[])x)).ToList();
-
-				Logger.Log(LogLevel.Debug, "Sideloader marker found");
-				Logger.Log(LogLevel.Debug, $"External info count: {extInfo.Count}");
-				foreach (ResolveInfo info in extInfo)
-					Logger.Log(LogLevel.Debug, $"External info: {info.GUID} : {info.Property} : {info.Slot}");
-			}
-
-			IterateCoordinatePrefixes(UniversalAutoResolver.ResolveStructure, file, extInfo);
-		}
-
-		private static void ExtendedCoordinateSave(ChaFileCoordinate file)
-		{
-			List<ResolveInfo> resolutionInfo = new List<ResolveInfo>();
-
-		    void IterateStruct(Dictionary<CategoryProperty, StructValue<int>> dict, object obj, IEnumerable<ResolveInfo> extInfo, string propertyPrefix = "")
-		    {
-		        foreach (var kv in dict)
-		        {
-		            int slot = kv.Value.GetMethod(obj);
-
-		            var info = UniversalAutoResolver.LoadedResolutionInfo.FirstOrDefault(x => x.Property == kv.Key.ToString() &&
-		                                                                                      x.LocalSlot == slot);
-
-			        if (info == null) 
-				        continue;
-
-
-			        var newInfo = info.DeepCopy();
-			        newInfo.Property = $"{propertyPrefix}{newInfo.Property}";
-
-			        kv.Value.SetMethod(obj, newInfo.Slot);
-
-			        resolutionInfo.Add(newInfo);
-		        }
-		    }
-
-			IterateCoordinatePrefixes(IterateStruct, file, null);
+            IterateCardPrefixes(IterateStruct, file, null);
 
             ExtendedSave.SetExtendedDataById(file, UniversalAutoResolver.UARExtID, new PluginData
-			{
-				data = new Dictionary<string, object>
-				{
-					["info"] = resolutionInfo.Select(x => x.Serialize()).ToList()
-				}
-			});
-		}
+            {
+                data = new Dictionary<string, object>
+                {
+                    ["info"] = resolutionInfo.Select(x => x.Serialize()).ToList()
+                }
+            });
+        }
 
-		[HarmonyPostfix, HarmonyPatch(typeof(ChaFileCoordinate), nameof(ChaFileCoordinate.SaveFile), new[] { typeof(string) })]
-		public static void ChaFileCoordinateSaveFilePostHook(ChaFileCoordinate __instance, string path)
-		{
-			Logger.Log(LogLevel.Debug, $"Reloading coordinate [{path}]");
+        [HarmonyPostfix, HarmonyPatch(typeof(ChaFile), "SaveFile", new[] { typeof(BinaryWriter), typeof(bool) })]
+        public static void ChaFileSaveFilePostHook(ChaFile __instance, bool __result, BinaryWriter bw, bool savePng)
+        {
+            Logger.Log(LogLevel.Debug, $"Reloading card [{__instance.charaFileName}]");
+
+            var extData = ExtendedSave.GetExtendedDataById(__instance, UniversalAutoResolver.UARExtID);
+
+            var tmpExtInfo = (List<byte[]>)extData.data["info"];
+            var extInfo = tmpExtInfo.Select(ResolveInfo.Unserialize).ToList();
+
+            Logger.Log(LogLevel.Debug, $"External info count: {extInfo.Count}");
+            foreach (ResolveInfo info in extInfo)
+                Logger.Log(LogLevel.Debug, $"External info: {info.GUID} : {info.Property} : {info.Slot}");
+
+            void ResetStructResolveStructure(Dictionary<CategoryProperty, StructValue<int>> propertyDict, object structure, IEnumerable<ResolveInfo> extInfo2, string propertyPrefix = "")
+            {
+                foreach (var kv in propertyDict)
+                {
+                    var extResolve = extInfo.FirstOrDefault(x => x.Property == $"{propertyPrefix}{kv.Key.ToString()}");
+
+                    if (extResolve != null)
+                    {
+                        kv.Value.SetMethod(structure, extResolve.LocalSlot);
+
+                        Logger.Log(LogLevel.Debug, $"[UAR] Resetting {extResolve.GUID}:{extResolve.Property} to internal slot {extResolve.LocalSlot}");
+                    }
+                }
+            }
+
+            IterateCardPrefixes(ResetStructResolveStructure, __instance, extInfo);
+        }
+
+        #endregion
+
+        #region ChaFileCoordinate
+
+        private static void IterateCoordinatePrefixes(Action<Dictionary<CategoryProperty, StructValue<int>>, object, IEnumerable<ResolveInfo>, string> action, ChaFileCoordinate coordinate, IEnumerable<ResolveInfo> extInfo)
+        {
+            action(StructReference.ChaFileClothesProperties, coordinate.clothes, extInfo, "");
+
+            for (int acc = 0; acc < coordinate.accessory.parts.Length; acc++)
+            {
+                string accPrefix = $"accessory{acc}.";
+
+                action(StructReference.ChaFileAccessoryPartsInfoProperties, coordinate.accessory.parts[acc], extInfo, accPrefix);
+            }
+        }
+
+        private static void ExtendedCoordinateLoad(ChaFileCoordinate file)
+        {
+            if (!IsResolving)
+                return;
+
+            Logger.Log(LogLevel.Debug, $"Loading coordinate [{file.coordinateName}]");
+
+            var extData = ExtendedSave.GetExtendedDataById(file, UniversalAutoResolver.UARExtID);
+            List<ResolveInfo> extInfo;
+
+            if (extData == null || !extData.data.ContainsKey("info"))
+            {
+                Logger.Log(LogLevel.Debug, "No sideloader marker found");
+                extInfo = null;
+            }
+            else
+            {
+                var tmpExtInfo = (object[])extData.data["info"];
+                extInfo = tmpExtInfo.Select(x => ResolveInfo.Unserialize((byte[])x)).ToList();
+
+                Logger.Log(LogLevel.Debug, "Sideloader marker found");
+                Logger.Log(LogLevel.Debug, $"External info count: {extInfo.Count}");
+                foreach (ResolveInfo info in extInfo)
+                    Logger.Log(LogLevel.Debug, $"External info: {info.GUID} : {info.Property} : {info.Slot}");
+            }
+
+            IterateCoordinatePrefixes(UniversalAutoResolver.ResolveStructure, file, extInfo);
+        }
+
+        private static void ExtendedCoordinateSave(ChaFileCoordinate file)
+        {
+            List<ResolveInfo> resolutionInfo = new List<ResolveInfo>();
+
+            void IterateStruct(Dictionary<CategoryProperty, StructValue<int>> dict, object obj, IEnumerable<ResolveInfo> extInfo, string propertyPrefix = "")
+            {
+                foreach (var kv in dict)
+                {
+                    int slot = kv.Value.GetMethod(obj);
+
+                    //No need to attempt a resolution info lookup for empty accessory slots and pattern slots
+                    if (slot == 0)
+                        continue;
+
+                    //Check if it's a vanilla item
+                    if (slot < 100000000)
+                        if (ResourceRedirector.ListLoader.InternalDataList[kv.Key.Category].ContainsKey(slot))
+                            continue;
+
+                    //For accessories, make sure we're checking the appropriate category
+                    if (kv.Key.Category.ToString().Contains("ao_"))
+                    {
+                        ChaFileAccessory.PartsInfo AccessoryInfo = (ChaFileAccessory.PartsInfo)obj;
+
+                        if ((int)kv.Key.Category != AccessoryInfo.type)
+                        {
+                            //If the current category does not match the accessory's category do not attempt a resolution info lookup
+                            continue;
+                        }
+                    }
+
+                    var info = UniversalAutoResolver.LoadedResolutionInfo.FirstOrDefault(x => x.Property == kv.Key.ToString() &&
+                                                                                              x.LocalSlot == slot);
+
+                    if (info == null)
+                        continue;
+
+                    var newInfo = info.DeepCopy();
+                    newInfo.Property = $"{propertyPrefix}{newInfo.Property}";
+
+                    kv.Value.SetMethod(obj, newInfo.Slot);
+
+                    resolutionInfo.Add(newInfo);
+                }
+            }
+
+            IterateCoordinatePrefixes(IterateStruct, file, null);
+
+            ExtendedSave.SetExtendedDataById(file, UniversalAutoResolver.UARExtID, new PluginData
+            {
+                data = new Dictionary<string, object>
+                {
+                    ["info"] = resolutionInfo.Select(x => x.Serialize()).ToList()
+                }
+            });
+        }
+
+        [HarmonyPostfix, HarmonyPatch(typeof(ChaFileCoordinate), nameof(ChaFileCoordinate.SaveFile), new[] { typeof(string) })]
+        public static void ChaFileCoordinateSaveFilePostHook(ChaFileCoordinate __instance, string path)
+        {
+            Logger.Log(LogLevel.Debug, $"Reloading coordinate [{path}]");
 
             var extData = ExtendedSave.GetExtendedDataById(__instance, UniversalAutoResolver.UARExtID);
 
@@ -247,40 +286,40 @@ namespace Sideloader.AutoResolver
             foreach (ResolveInfo info in extInfo)
                 Logger.Log(LogLevel.Debug, $"External info: {info.GUID} : {info.Property} : {info.Slot}");
 
-		    void ResetStructResolveStructure(Dictionary<CategoryProperty, StructValue<int>> propertyDict, object structure, IEnumerable<ResolveInfo> extInfo2, string propertyPrefix = "")
-		    {
-		        foreach (var kv in propertyDict)
-		        {
-		            var extResolve = extInfo.FirstOrDefault(x => x.Property == $"{propertyPrefix}{kv.Key.ToString()}");
+            void ResetStructResolveStructure(Dictionary<CategoryProperty, StructValue<int>> propertyDict, object structure, IEnumerable<ResolveInfo> extInfo2, string propertyPrefix = "")
+            {
+                foreach (var kv in propertyDict)
+                {
+                    var extResolve = extInfo.FirstOrDefault(x => x.Property == $"{propertyPrefix}{kv.Key.ToString()}");
 
-		            if (extResolve != null)
-		            {
-		                kv.Value.SetMethod(structure, extResolve.LocalSlot);
+                    if (extResolve != null)
+                    {
+                        kv.Value.SetMethod(structure, extResolve.LocalSlot);
 
-		                Logger.Log(LogLevel.Debug, $"[UAR] Resetting {extResolve.GUID}:{extResolve.Property} to internal slot {extResolve.LocalSlot}");
-		            }
-		        }
-		    }
+                        Logger.Log(LogLevel.Debug, $"[UAR] Resetting {extResolve.GUID}:{extResolve.Property} to internal slot {extResolve.LocalSlot}");
+                    }
+                }
+            }
 
-		    IterateCoordinatePrefixes(ResetStructResolveStructure, __instance, extInfo);
+            IterateCoordinatePrefixes(ResetStructResolveStructure, __instance, extInfo);
         }
 
-		#endregion
+        #endregion
 
-		#region CustomScnene Load Hooks
-		
-		[HarmonyPrefix, HarmonyPatch(typeof(CustomCharaFile), "Initialize")]
-		public static void CustomScenePreHook()
-		{
-			IsResolving = false;
-		}
+        #region CustomScnene Load Hooks
 
-		[HarmonyPostfix, HarmonyPatch(typeof(CustomCharaFile), "Initialize")]
-		public static void CustomScenePostHook()
-		{
-			IsResolving = true;
-		}
+        [HarmonyPrefix, HarmonyPatch(typeof(CustomCharaFile), "Initialize")]
+        public static void CustomScenePreHook()
+        {
+            IsResolving = false;
+        }
 
-		#endregion
-	}
+        [HarmonyPostfix, HarmonyPatch(typeof(CustomCharaFile), "Initialize")]
+        public static void CustomScenePostHook()
+        {
+            IsResolving = true;
+        }
+
+        #endregion
+    }
 }

--- a/Sideloader/AutoResolver/UniversalAutoResolver.cs
+++ b/Sideloader/AutoResolver/UniversalAutoResolver.cs
@@ -23,10 +23,9 @@ namespace Sideloader.AutoResolver
                 {
                     //the property does not have external slot information
                     //check if we have a corrosponding item for backwards compatbility
-
                     var intResolve = LoadedResolutionInfo.FirstOrDefault(x => x.Property == kv.Key.ToString()
-                                                                              && x.Slot == kv.Value.GetMethod(structure)
-                                                                              && x.CategoryNo == kv.Key.Category);
+                                                                           && x.Slot == kv.Value.GetMethod(structure)
+                                                                           && x.CategoryNo == kv.Key.Category);
 
                     if (intResolve != null)
                     {
@@ -38,6 +37,7 @@ namespace Sideloader.AutoResolver
                     else
                     {
                         //No match was found
+                        Logger.Log(LogLevel.Debug, $"[UAR] Compatibility resolving failed, no match found for ID {kv.Value.GetMethod(structure)} Category {kv.Key.Category}");
                     }
                 }
                 else
@@ -71,7 +71,12 @@ namespace Sideloader.AutoResolver
                     if (extResolve != null)
                     {
                         //the property has external slot information 
-                        var intResolve = LoadedResolutionInfo.FirstOrDefault(x => x.AppendPropertyPrefix(propertyPrefix).CanResolve(extResolve)
+                        //var intResolve = LoadedResolutionInfo.FirstOrDefault(x => x.AppendPropertyPrefix(propertyPrefix).CanResolve(extResolve)
+                        //                                                       && x.CategoryNo == kv.Key.Category);
+
+                        var intResolve = LoadedResolutionInfo.FirstOrDefault(x => x.Property == kv.Key.ToString()
+                                                                               && x.Slot == extResolve.Slot
+                                                                               && x.GUID == extResolve.GUID
                                                                                && x.CategoryNo == kv.Key.Category);
 
                         if (intResolve != null)
@@ -119,20 +124,14 @@ namespace Sideloader.AutoResolver
 
             var propertyKeys = StructReference.CollatedStructValues.Keys.Where(x => x.Category == category).ToList();
 
-            //Logger.Log(LogLevel.Debug, category.ToString());
             //Logger.Log(LogLevel.Debug, StructReference.CollatedStructValues.Count.ToString());
-
 
             foreach (var kv in data.dictList)
             {
                 int newSlot = Interlocked.Increment(ref CurrentSlotID);
 
-                //Logger.Log(LogLevel.Debug, kv.Value[0] + " | " + newSlot);
-
                 foreach (var propertyKey in propertyKeys)
                 {
-                    //Logger.Log(LogLevel.Debug, propertyKey.ToString());
-
                     LoadedResolutionInfo.Add(new ResolveInfo
                     {
                         GUID = manifest.GUID,
@@ -142,15 +141,17 @@ namespace Sideloader.AutoResolver
                         CategoryNo = category
                     });
 
-                    //Logger.Log(LogLevel.Debug, $"LOADED COUNT {LoadedResolutionInfo.Count}");
+                    //Logger.Log(LogLevel.Info, $"ResolveInfo - " +
+                    //                          $"GUID: {manifest.GUID} " +
+                    //                          $"Slot: {int.Parse(kv.Value[0])} " +
+                    //                          $"LocalSlot: {newSlot} " +
+                    //                          $"Property: {propertyKey.ToString()} " +
+                    //                          $"CategoryNo: {category} " +
+                    //                          $"Total Count: {LoadedResolutionInfo.Count}");
                 }
 
                 kv.Value[0] = newSlot.ToString();
             }
-
-            //Logger.Log(LogLevel.Debug, $"Internal info count: {LoadedResolutionInfo.Count}");
-            //foreach (ResolveInfo info in LoadedResolutionInfo)
-            //    Logger.Log(LogLevel.Debug, $"Internal info: {info.GUID} : {info.Property} : {info.Slot}");
         }
     }
 }

--- a/Sideloader/Hooks.cs
+++ b/Sideloader/Hooks.cs
@@ -3,20 +3,31 @@
 namespace Sideloader
 {
     public static class Hooks
-	{
-		public static void InstallHooks()
-		{
-			var harmony = HarmonyInstance.Create("com.bepis.bepinex.sideloader");
-			harmony.PatchAll(typeof(Hooks));
-		}
+    {
+        public static void InstallHooks()
+        {
+            var harmony = HarmonyInstance.Create("com.bepis.bepinex.sideloader");
+            harmony.PatchAll(typeof(Hooks));
+        }
 
-		[HarmonyPostfix, HarmonyPatch(typeof(AssetBundleCheck), nameof(AssetBundleCheck.IsFile))]
-		public static void IsFileHook(string assetBundleName, ref bool __result)
-		{
-		    if (BundleManager.Bundles.ContainsKey(assetBundleName))
-		    {
-		        __result = true;
-		    }
-		}
-	}
+        [HarmonyPostfix, HarmonyPatch(typeof(AssetBundleCheck), nameof(AssetBundleCheck.IsFile))]
+        public static void IsFileHook(string assetBundleName, ref bool __result)
+        {
+            if (BundleManager.Bundles.ContainsKey(assetBundleName))
+            {
+                __result = true;
+            }
+        }
+
+        [HarmonyPostfix]
+        [HarmonyPatch(typeof(AssetBundleData))]
+        [HarmonyPatch(nameof(AssetBundleData.isFile), PropertyMethod.Getter)]
+        public static void IsFileHook2(ref bool __result, AssetBundleData __instance)
+        {
+            if (BundleManager.Bundles.ContainsKey(__instance.bundle))
+            {
+                __result = true;
+            }
+        }
+    }
 }


### PR DESCRIPTION
On UniversalAutoResolver.cs I changed var intResolve = LoadedResolutionInfo.FirstOrDefault. I actually have no idea how/why this works, but the old way would save a heavily modded character with full sideloader modpack in 40 seconds, new way saves it in 1 second. Left the old way commented out for reference.

On Hooks.cs it's hard to tell what changes were made since I used format document to fix all the whitespace, but in ExtendedCardSave and ExtendedCoordinateSave I added some checks so that the LoadedResolutionInfo list wont be read unless it's likely to be a modded item. Before this change it was accessing it 11 times per accessory, per slot (even if empty), per outfit. Reading through that entire list 1500+ times took a very long time. Now an entire class of lightly modded characters saves in about a second.

Also removed makeup stuff from IterateCoordinatePrefixes since coordinates don't save makeup data anyway.