### PR TITLE
Add asset bundles for folders in sideloader mods that do not match an existing one

### DIFF
--- a/Sideloader/Hooks.cs
+++ b/Sideloader/Hooks.cs
@@ -1,4 +1,7 @@
-﻿using Harmony;
+﻿using BepInEx;
+using BepInEx.Logging;
+using Logger = BepInEx.Logger;
+using Harmony;
 
 namespace Sideloader
 {
@@ -13,9 +16,12 @@ namespace Sideloader
         [HarmonyPostfix, HarmonyPatch(typeof(AssetBundleCheck), nameof(AssetBundleCheck.IsFile))]
         public static void IsFileHook(string assetBundleName, ref bool __result)
         {
-            if (BundleManager.Bundles.ContainsKey(assetBundleName))
+            if (!__result)
             {
-                __result = true;
+                if (BundleManager.Bundles.ContainsKey(assetBundleName))
+                    __result = true;
+                if (Sideloader.IsPngFolderOnly(assetBundleName))
+                    __result = true;
             }
         }
 
@@ -24,9 +30,12 @@ namespace Sideloader
         [HarmonyPatch(nameof(AssetBundleData.isFile), PropertyMethod.Getter)]
         public static void IsFileHook2(ref bool __result, AssetBundleData __instance)
         {
-            if (BundleManager.Bundles.ContainsKey(__instance.bundle))
+            if (!__result)
             {
-                __result = true;
+                if (BundleManager.Bundles.ContainsKey(__instance.bundle))
+                    __result = true;
+                if (Sideloader.IsPngFolderOnly(__instance.bundle))
+                    __result = true;
             }
         }
     }

--- a/Sideloader/Sideloader.cs
+++ b/Sideloader/Sideloader.cs
@@ -257,10 +257,11 @@ namespace Sideloader
         /// </summary>
         public static bool IsPngFolderOnly(string assetBundleName)
         {
-            if (PngFolderOnlyList.Contains(assetBundleName.Remove(assetBundleName.LastIndexOf('.'))))
+            var extStart = assetBundleName.LastIndexOf('.');
+            var trimmedName = extStart >= 0 ? assetBundleName.Remove(extStart) : assetBundleName;
+            if (PngFolderOnlyList.Contains(trimmedName))
                 return true;
-            else
-                return false;
+            return false;
         }
         /// <summary>
         /// Check whether the .png file comes from a sideloader mod

--- a/Sideloader/Sideloader.cs
+++ b/Sideloader/Sideloader.cs
@@ -25,6 +25,11 @@ namespace Sideloader
 
         protected List<Manifest> LoadedManifests = new List<Manifest>();
 
+        protected static Dictionary<string, ZipFile> PngList = new Dictionary<string, ZipFile>();
+        protected static List<string> PngFolderList = new List<string>();
+        protected static List<string> PngFolderOnlyList = new List<string>();
+
+
         public static Dictionary<Manifest, List<ChaListData>> LoadedData { get; } = new Dictionary<Manifest, List<ChaListData>>();
 
         public Sideloader()
@@ -93,7 +98,6 @@ namespace Sideloader
             }
 
             // Handlie duplicate GUIDs and load unique mods
-            List<string> pngFolderList = new List<string>();
             foreach (var modGroup in archives.GroupBy(x => x.Value.GUID))
             {
                 // Order by version if available, else use modified dates (less reliable)
@@ -124,7 +128,7 @@ namespace Sideloader
 
                     LoadAllUnityArchives(archive, archive.Name);
                     LoadAllLists(archive, manifest);
-                    BuildPngFolderList(archive, ref pngFolderList);
+                    BuildPngFolderList(archive);
 
                     var trimmedName = manifest.Name?.Trim();
                     var displayName = !string.IsNullOrEmpty(trimmedName) ? trimmedName : Path.GetFileName(archive.Name);
@@ -137,7 +141,7 @@ namespace Sideloader
                     Logger.Log(LogLevel.Debug, $"[SIDELOADER] Error details: {ex}");
                 }
             }
-            LoadAllPngArchives(pngFolderList);
+            BuildPngOnlyFolderList();
         }
 
         protected void SetPossessNew(ChaListData data)
@@ -202,6 +206,72 @@ namespace Sideloader
                 }
             }
         }
+        /// <summary>
+        /// Construct a list of all folders that contain a .png
+        /// </summary>
+        protected void BuildPngFolderList(ZipFile arc)
+        {
+            foreach (ZipEntry entry in arc)
+            {
+                //Only list folders for .pngs in abdata folder
+                //i.e. skip preview pics or character cards that might be included with the mod
+                if (entry.Name.StartsWith("abdata/", StringComparison.OrdinalIgnoreCase) && entry.Name.EndsWith(".png", StringComparison.OrdinalIgnoreCase))
+                {
+                    //Make a list of all the .png files and archive they come from
+                    PngList.Add(entry.Name, arc);
+
+                    string assetBundlePath = entry.Name;
+
+                    //Remove the .png filename and "abdata/"
+                    assetBundlePath = assetBundlePath.Remove(assetBundlePath.LastIndexOf('/')).Remove(0, assetBundlePath.IndexOf('/') + 1);
+                    if (!PngFolderList.Contains(assetBundlePath))
+                    {
+                        //Make a unique list of all folders that contain a .png
+                        PngFolderList.Add(assetBundlePath);
+                    }
+                }
+            }
+        }
+        /// <summary>
+        /// Build a list of folders that contain .pngs but do not match an existing asset bundle
+        /// </summary>
+        protected void BuildPngOnlyFolderList()
+        {
+            foreach (string folder in PngFolderList) //assetBundlePath
+            {
+                string assetBundlePath = folder + ".unity3d";
+
+                //The file exists at this location, no need to add a bundle
+                if (File.Exists(Application.dataPath + "/../abdata/" + assetBundlePath))
+                    continue;
+
+                //Bundle has already been added by LoadAllUnityArchives
+                if (BundleManager.Bundles.ContainsKey(assetBundlePath))
+                    continue;
+
+                PngFolderOnlyList.Add(folder);
+            }
+        }
+        /// <summary>
+        /// Check whether the asset bundle matches a folder that contains .png files and does not match an existing asset bundle
+        /// </summary>
+        public static bool IsPngFolderOnly(string assetBundleName)
+        {
+            if (PngFolderOnlyList.Contains(assetBundleName.Remove(assetBundleName.LastIndexOf('.'))))
+                return true;
+            else
+                return false;
+        }
+        /// <summary>
+        /// Check whether the .png file comes from a sideloader mod
+        /// </summary>
+        public static bool IsPng(string pngFile)
+        {
+            if (PngList.ContainsKey(pngFile))
+                return true;
+            else
+                return false;
+        }
 
         private static MethodInfo locateZipEntryMethodInfo = typeof(ZipFile).GetMethod("LocateEntry", BindingFlags.NonPublic | BindingFlags.Instance);
 
@@ -255,65 +325,6 @@ namespace Sideloader
                 }
             }
         }
-        /// <summary>
-        /// Construct a list of all folders that contain a .png
-        /// </summary>
-        protected void BuildPngFolderList(ZipFile arc, ref List<string> pngFolderList)
-        {
-            foreach (ZipEntry entry in arc)
-            {
-                //Only list folders for .pngs in abdata folder
-                //i.e. skip preview pics or character cards that might be included with the mod
-                if (entry.Name.StartsWith("abdata/", StringComparison.OrdinalIgnoreCase) && entry.Name.EndsWith(".png", StringComparison.OrdinalIgnoreCase))
-                {
-                    string assetBundlePath = entry.Name;
-
-                    //Remove the .png filename
-                    assetBundlePath = assetBundlePath.Remove(assetBundlePath.LastIndexOf('/'));
-
-                    if (!pngFolderList.Contains(assetBundlePath))
-                    {
-                        pngFolderList.Add(assetBundlePath);
-                    }
-                }
-            }
-        }
-        /// <summary>
-        /// Use the list of folders that contain .png files to construct an asset bundle for each one that does not match an existing asset bundle
-        /// </summary>
-        protected void LoadAllPngArchives(List<string> pngFolderList)
-        {
-            foreach (string folderPath in pngFolderList)
-            {
-                //Remove "abdata/" from file path and add ".unity3d" to the folder name
-                string assetBundlePath = folderPath.Remove(0, folderPath.IndexOf('/') + 1) + ".unity3d";
-
-                if (File.Exists(Application.dataPath + "/../abdata/" + assetBundlePath))
-                {
-                    //The file exists at this location, no need to add a bundle
-                    continue;
-                }
-                else if (BundleManager.Bundles.ContainsKey(assetBundlePath))
-                {
-                    //Bundle has already been added by LoadAllUnityArchives
-                    continue;
-                }
-                else
-                {
-                    //Create a new bundle and add it to the list of bundles
-                    Func<AssetBundle> getBundleFunc = () =>
-                    {
-                        return new AssetBundle();
-                    };
-
-                    BundleManager.AddBundleLoader(getBundleFunc, assetBundlePath, out string warning);
-
-                    if (!string.IsNullOrEmpty(warning))
-                        Logger.Log(LogLevel.Warning, $"[SIDELOADER] WARNING! {warning}");
-                }
-            }
-
-        }
 
         protected bool RedirectHook(string assetBundleName, string assetName, Type type, string manifestAssetBundleName, out AssetBundleLoadAssetOperation result)
         {
@@ -323,7 +334,8 @@ namespace Sideloader
             {
                 zipPath = $"{zipPath}.png";
 
-                foreach (var archive in Archives)
+                //Only search the archives for a .png that can actually be found
+                if (PngList.TryGetValue(zipPath, out ZipFile archive))
                 {
                     var entry = archive.GetEntry(zipPath);
 
@@ -339,6 +351,16 @@ namespace Sideloader
                             tex.wrapMode = TextureWrapMode.Repeat;
 
                         result = new AssetBundleLoadAssetOperationSimulation(tex);
+                        return true;
+                    }
+                }
+                else
+                {
+                    if (IsPngFolderOnly(assetBundleName))
+                    {
+                        //A .png that does not exist is being requested from from an asset bundle that does not exist
+                        //Return an empty image to prevent crashing
+                        result = new AssetBundleLoadAssetOperationSimulation(new Texture2D(0, 0));
                         return true;
                     }
                 }


### PR DESCRIPTION
If .png files are in a folder and the folder name does not match an existing .unity3d file the textures will never load. By making a list of all folders in sideloader mods that contain .png files and then creating a new asset bundle when needed, such textures will load correctly.